### PR TITLE
dt2s config and immersive mode tile

### DIFF
--- a/packages/SystemUI/res/drawable/ic_qs_immersive_full.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_immersive_full.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 nAOSProm
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,0l-5,5l3,0l0,5l4,0l0,-5l3,0z"/>
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10,14l0,5l-3,0l5,5l5,-5l-3,0l0,-5z"/>
+</vector>

--- a/packages/SystemUI/res/drawable/ic_qs_immersive_nav.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_immersive_nav.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 nAOSProm
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,2l0,3l16,0l0,-3z"/>
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10,9l0,9l-3,0l5,5l5,-5l-3,0l0,-9z"/>
+</vector>

--- a/packages/SystemUI/res/drawable/ic_qs_immersive_off.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_immersive_off.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 nAOSProm
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#4DFFFFFF"
+        android:pathData="M12,0l-4,4l6,6l0,-5l3,0z"/>
+    <path
+        android:fillColor="#4DFFFFFF"
+        android:pathData="M10,14l0,5l-3,0l5,5l5,-5l-3,0l0,-5z"/>
+    <path
+        android:fillColor="#4DFFFFFF"
+        android:pathData="M4,3l-1,1l17,17l1,-1z"/>
+</vector>

--- a/packages/SystemUI/res/drawable/ic_qs_immersive_status.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_immersive_status.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 nAOSProm
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,1l-5,5l3,0l0,8l4,0l0,-8l3,0z"/>
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,18l0,4l16,0l0,-4z"/>
+</vector>

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -119,7 +119,7 @@
 
     <!-- The default tiles to display in QuickSettings -->
     <string name="quick_settings_tiles_default" translatable="false">
-        wifi,bt,inversion,dnd,cell,airplane,rotation,flashlight,location,cast,hotspot,fastcharge,screencolor,lockscreen,network_adb,caffeine
+        wifi,bt,inversion,dnd,cell,airplane,rotation,flashlight,location,cast,hotspot,fastcharge,screencolor,lockscreen,network_adb,caffeine,immersive_mode
     </string>
 
     <!-- The tiles to display in QuickSettings -->

--- a/packages/SystemUI/res/values/urom_strings.xml
+++ b/packages/SystemUI/res/values/urom_strings.xml
@@ -33,4 +33,12 @@
     <string name="accessibility_quick_settings_caffeine_off">Caffeine off.</string>
     <!-- Content description of the caffeine tile in quick settings when on (not shown on the screen). [CHAR LIMIT=NONE] -->
     <string name="accessibility_quick_settings_caffeine_on">Caffeine on.</string>
+
+    <!-- Immersive Mode tile Tile -->
+    <string name="quick_settings_immersive_mode_label">Immersive mode</string>
+    <string name="qs_tile_immersive_mode_off">Immersive mode off</string>
+    <string name="qs_tile_immersive_mode_full_screen">Full screen</string>
+    <string name="qs_tile_immersive_mode_navbar_hidden">Navigation hidden</string>
+    <string name="qs_tile_immersive_mode_status_hidden">Status bar hidden</string>
 </resources>
+

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/ImmersiveModeTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/ImmersiveModeTile.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2016 nAOSProm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.qs.tiles;
+
+import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.SystemClock;
+import android.os.RemoteException;
+import android.provider.Settings;
+import android.view.WindowManagerGlobal;
+
+import com.android.internal.logging.MetricsConstants;
+import com.android.systemui.qs.QSTile;
+import com.android.systemui.R;
+
+/** Quick settings tile: ImmersiveMode **/
+public class ImmersiveModeTile extends QSTile<QSTile.BooleanState> {
+    private static final int IMMERSIVE_MODE_OFF = 0;
+    private static final int IMMERSIVE_MODE_FULL = 1;
+    private static final int IMMERSIVE_MODE_HIDE_NAVIGATION = 2;
+    private static final int IMMERSIVE_MODE_HIDE_STATUS_BAR = 3;
+
+    private static final String [] POLICY_CONTROL_VALUES = {
+        null, "immersive.full=*", "immersive.navigation=*", "immersive.status=*"
+    };
+
+    private int mActiveImmersiveMode = 0;
+    private long mLastClickTime = -1;
+    private ContentObserver mContentObserver;
+    private boolean mModeChanged = false;
+    private boolean mHasNavigationBar;
+
+    public ImmersiveModeTile(Host host) {
+        super(host);
+        init();
+    }
+
+    private void init() {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        Uri setting = Settings.Global.getUriFor(Settings.Global.POLICY_CONTROL);
+        mContentObserver = new ContentObserver(new Handler()) {
+            @Override
+            public void onChange(boolean selfChange) {
+                super.onChange(selfChange);
+                updateActiveImmersiveMode();
+            }
+
+            @Override
+            public boolean deliverSelfNotifications() {
+                return true;
+            }
+        };
+        try {
+            mHasNavigationBar = WindowManagerGlobal.getWindowManagerService().hasNavigationBar();
+        } catch (RemoteException ex) {
+        }
+    }
+
+    @Override
+    protected BooleanState newTileState() {
+        return new BooleanState();
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsConstants.QS_PANEL;
+    }
+
+    @Override
+    public void setListening(boolean listening) {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        if (listening) {
+            Uri setting = Settings.Global.getUriFor(Settings.Global.POLICY_CONTROL);
+            contentResolver.registerContentObserver(setting, false, mContentObserver);
+        } else {
+            contentResolver.unregisterContentObserver(mContentObserver);
+            if (mModeChanged) {
+                String policyControl = POLICY_CONTROL_VALUES[mActiveImmersiveMode];
+                Settings.Global.putString(mContext.getContentResolver(),  Settings.Global.POLICY_CONTROL, policyControl);
+                mModeChanged = false;
+            }
+        }
+    }
+
+    @Override
+    public void handleClick() {
+        boolean wasEnabled = (Boolean) mState.value;
+        if (!wasEnabled) {
+            mActiveImmersiveMode = IMMERSIVE_MODE_FULL;
+        } else if (mHasNavigationBar && SystemClock.elapsedRealtime() - mLastClickTime < 5000) {
+            mActiveImmersiveMode = (mActiveImmersiveMode + 1) % 4;
+        } else {
+            mActiveImmersiveMode = IMMERSIVE_MODE_OFF;
+        }
+        mModeChanged = true;
+        mLastClickTime = SystemClock.elapsedRealtime();
+        refreshState();
+    }
+    
+    private void updateActiveImmersiveMode() {
+        String policyControl = Settings.Global.getString(mContext.getContentResolver(),
+                        Settings.Global.POLICY_CONTROL);
+        mActiveImmersiveMode = IMMERSIVE_MODE_OFF;
+        if (policyControl != null) {
+            for(int i = 1; i < 4; i++)    {
+                if (POLICY_CONTROL_VALUES[i].equals(policyControl)) {
+                    mActiveImmersiveMode = mHasNavigationBar ? i : 1;
+                    break;
+                }
+            }
+        }
+        mModeChanged = false;
+        refreshState();  
+    }
+
+    @Override
+    protected void handleUpdateState(BooleanState state, Object arg) {
+        state.value = (mActiveImmersiveMode != IMMERSIVE_MODE_OFF);
+        state.visible = true;
+        switch (mActiveImmersiveMode) {
+        case IMMERSIVE_MODE_OFF:
+            state.label = mContext.getString(R.string.quick_settings_immersive_mode_label);
+            state.icon = ResourceIcon.get(R.drawable.ic_qs_immersive_off);
+            state.contentDescription =  mContext.getString(R.string.qs_tile_immersive_mode_off);
+            break;
+        case IMMERSIVE_MODE_FULL:
+            state.label = mContext.getString(R.string.qs_tile_immersive_mode_full_screen);
+            state.icon = ResourceIcon.get(R.drawable.ic_qs_immersive_full);
+            state.contentDescription =  mContext.getString(R.string.qs_tile_immersive_mode_full_screen);
+            break;
+        case IMMERSIVE_MODE_HIDE_NAVIGATION:
+            state.label = mContext.getString(R.string.qs_tile_immersive_mode_navbar_hidden);
+            state.icon = ResourceIcon.get(R.drawable.ic_qs_immersive_nav);
+            state.contentDescription =  mContext.getString(R.string.qs_tile_immersive_mode_navbar_hidden);
+            break;
+        case IMMERSIVE_MODE_HIDE_STATUS_BAR:
+            state.label = mContext.getString(R.string.qs_tile_immersive_mode_status_hidden);
+            state.icon = ResourceIcon.get(R.drawable.ic_qs_immersive_status);
+            state.contentDescription =  mContext.getString(R.string.qs_tile_immersive_mode_status_hidden);
+            break;
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -221,24 +221,27 @@ public class NotificationPanelView extends PanelView implements
     private final Interpolator mTouchResponseInterpolator =
             new PathInterpolator(0.3f, 0f, 0.1f, 1f);
 
-    private boolean mDoubleTapToSleepEnabled = true;
+    private boolean mDoubleTapToSleepEnabled;
     private int mStatusBarHeaderHeight;
     private GestureDetector mDoubleTapGesture;
 
     public NotificationPanelView(Context context, AttributeSet attrs) {
         super(context, attrs);
         setWillNotDraw(!DEBUG);
-        mDoubleTapGesture = new GestureDetector(mContext, new GestureDetector.SimpleOnGestureListener() {
-            @Override
-            public boolean onDoubleTap(MotionEvent e) {
-                PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
-                if(pm != null)
-                    pm.goToSleep(e.getEventTime());
-                return true;
-            }
-        });
 
         mOneFingerQsExpandPossible = SystemProperties.getBoolean("persist.sys.qs_onefinger", true);
+        mDoubleTapToSleepEnabled = SystemProperties.getBoolean("persist.sys.statusbar.dt2s", true);
+        if (mDoubleTapToSleepEnabled) {
+            mDoubleTapGesture = new GestureDetector(mContext, new GestureDetector.SimpleOnGestureListener() {
+                @Override
+                public boolean onDoubleTap(MotionEvent e) {
+                    PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
+                    if(pm != null)
+                        pm.goToSleep(e.getEventTime());
+                    return true;
+                }
+            });
+        }
     }
 
     public void setStatusBar(PhoneStatusBar bar) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/QSTileHost.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/QSTileHost.java
@@ -38,6 +38,7 @@ import com.android.systemui.qs.tiles.DndTile;
 import com.android.systemui.qs.tiles.FastChargeTile;
 import com.android.systemui.qs.tiles.FlashlightTile;
 import com.android.systemui.qs.tiles.HotspotTile;
+import com.android.systemui.qs.tiles.ImmersiveModeTile;
 import com.android.systemui.qs.tiles.IntentTile;
 import com.android.systemui.qs.tiles.LocationTile;
 import com.android.systemui.qs.tiles.LockscreenToggleTile;
@@ -270,6 +271,7 @@ public class QSTileHost implements QSTile.Host, Tunable {
         else if (tileSpec.equals("lockscreen")) return  new LockscreenToggleTile(this);
         else if (tileSpec.equals("network_adb")) return new AdbOverNetworkTile(this);
         else if (tileSpec.equals("caffeine")) return new CaffeineTile(this);
+        else if (tileSpec.equals("immersive_mode")) return new ImmersiveModeTile(this);
         else if (tileSpec.startsWith(IntentTile.PREFIX)) return IntentTile.create(this,tileSpec);
         else throw new IllegalArgumentException("Bad tile spec: " + tileSpec);
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowView.java
@@ -27,6 +27,7 @@ import android.graphics.Rect;
 import android.media.session.MediaSessionLegacyHelper;
 import android.os.IBinder;
 import android.os.PowerManager;
+import android.os.SystemProperties;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
@@ -58,7 +59,7 @@ public class StatusBarWindowView extends FrameLayout {
     private PhoneStatusBar mService;
     private final Paint mTransparentSrcPaint = new Paint();
 
-    private boolean mDoubleTapToSleepEnabled = true;
+    private boolean mDoubleTapToSleepEnabled;
     private int mStatusBarHeaderHeight;
     private GestureDetector mDoubleTapGesture;
 
@@ -70,16 +71,18 @@ public class StatusBarWindowView extends FrameLayout {
         mStatusBarHeaderHeight = context
                 .getResources().getDimensionPixelSize(R.dimen.status_bar_header_height);
 
-        mDoubleTapGesture = new GestureDetector(mContext, new GestureDetector.SimpleOnGestureListener() {
-            @Override
-            public boolean onDoubleTap(MotionEvent e) {
-                PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
-                if(pm != null)
-                    pm.goToSleep(e.getEventTime());
-                return true;
-            }
-        });
-
+        mDoubleTapToSleepEnabled = SystemProperties.getBoolean("persist.sys.statusbar.dt2s", true);
+        if (mDoubleTapToSleepEnabled) {
+            mDoubleTapGesture = new GestureDetector(mContext, new GestureDetector.SimpleOnGestureListener() {
+                @Override
+                public boolean onDoubleTap(MotionEvent e) {
+                    PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
+                    if(pm != null)
+                        pm.goToSleep(e.getEventTime());
+                    return true;
+                }
+            });
+        }
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/systemui/tuner/QsTuner.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/QsTuner.java
@@ -205,6 +205,7 @@ public class QsTuner extends Fragment implements Callback {
         else if (spec.equals("lockscreen")) return R.string.quick_settings_lockscreen_label;
         else if (spec.equals("network_adb")) return R.string.quick_settings_network_adb_label;
         else if (spec.equals("caffeine")) return R.string.quick_settings_caffeine_label;
+        else if (spec.equals("immersive_mode")) return R.string.quick_settings_immersive_mode_label;
         return 0;
     }
 
@@ -453,6 +454,7 @@ public class QsTuner extends Fragment implements Callback {
             else if (mSpec.equals("lockscreen")) return R.drawable.ic_qs_lock_screen_on;
             else if (mSpec.equals("network_adb")) return R.drawable.ic_qs_network_adb_on;
             else if (mSpec.equals("caffeine")) return R.drawable.ic_qs_caffeine_on;
+            else if (mSpec.equals("immersive_mode")) return R.drawable.ic_qs_immersive_full;
             return R.drawable.android;
         }
 


### PR DESCRIPTION
Hi mickybart,

I've implemented status bar double tap to sleep configuration to nAOSP more settings - user can turn off dt2s if he doesn't want that feature.
I have also implemented immersive mode quick settings tile which can hide status bar (and navigation bar if enabled). This feature I've implemented for N7, where it's very useful for landscape mode, but it can be useful on XS too.
