### PR TITLE
fixed crash in Gallery video player

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -802,6 +802,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     break;
                 case MSG_DISPOSE_INPUT_CONSUMER:
                     disposeInputConsumer((InputConsumer) msg.obj);
+                    break;
                 case MSG_DISPATCH_VOLKEY_WITH_WAKE_LOCK:
                     KeyEvent event = (KeyEvent) msg.obj;
                     mQemuHwMainkeysIsLongPress = true;


### PR DESCRIPTION
This is crash stacktrace:

--------- beginning of crash
09-30 18:13:24.393   428   443 E AndroidRuntime: **\* FATAL EXCEPTION IN SYSTEM PROCESS: android.ui
09-30 18:13:24.393   428   443 E AndroidRuntime: java.lang.ClassCastException: com.android.server.wm.WindowManagerService$HideNavInputConsumer cannot be cast to android.view.KeyEvent
09-30 18:13:24.393   428   443 E AndroidRuntime:    at com.android.server.policy.PhoneWindowManager$PolicyHandler.handleMessage(PhoneWindowManager.java:806)
09-30 18:13:24.393   428   443 E AndroidRuntime:    at android.os.Handler.dispatchMessage(Handler.java:102)
09-30 18:13:24.393   428   443 E AndroidRuntime:    at android.os.Looper.loop(Looper.java:154)
09-30 18:13:24.393   428   443 E AndroidRuntime:    at android.os.HandlerThread.run(HandlerThread.java:61)
09-30 18:13:24.393   428   443 E AndroidRuntime:    at com.android.server.ServiceThread.run(ServiceThread.java:46)

We're obviously missing break in the case, so we're getting invalid cast.
